### PR TITLE
WS-1626 Implement a merge-bot for PR's

### DIFF
--- a/.bulldozer.yml
+++ b/.bulldozer.yml
@@ -7,7 +7,7 @@ merge:
     squash:
       title: "pull_request_title"
       body: "pull_request_body"
-  delete_after_merge: false
+  delete_after_merge: true
   allow_merge_with_no_checks: true
 update:
   ignore_drafts: true


### PR DESCRIPTION
## Purpose/Bug 
Need configuration for bulldozer PR merge-bot

## Approach 
Added global default `.bulldozer.yml` with the following setup:
- Do not auto-merge PRs with the "HOLD" label
- Squash commits using the PR title as the commit title and the PR body as the commit message
- Do not delete branches after merging
- Allow auto merging branches without status checks
- Auto update PR branches with changes from target branch when available

## Related Pull Requests
Similar repo-specific `.bulldozer.yml`s for the following repositories, requiring successful status checks in order to merge:
- WS-1626 frontend
- WS-1626 backend
- WS-1626 planhat
- WS-1626 scheduler

## Checklist
_Before submitting the PR to the team, please fill out the self-review below_
- [ ] I have reviewed the code changes
- [ ] I have tested the changes in a local environment
- [ ] My style conforms to the rest of the code base

## Reviewers:
@wildsparq/developers 