### PR TITLE
WS-2552 Support for passing Docker build args into composite build action

### DIFF
--- a/workflows/composite/build-and-publish-image/action.yml
+++ b/workflows/composite/build-and-publish-image/action.yml
@@ -24,9 +24,9 @@ inputs:
     required: false
     default: 'linux/amd64'
     description: 'The architectures for which to build the images'
-  build_args:
+  build_options:
     required: false
-    description: "Additional arguments for the docker build"
+    description: "Additional options for the docker build"
 
 runs:
   using: "composite"
@@ -42,8 +42,7 @@ runs:
         # push it to ECR so that it can
         # be deployed to ECS.
         IMAGE_NAME=$ECR_REGISTRY/${{inputs.repository_name}}:${{inputs.image_name}}
-        ARGS_OPT=$([[ "${{inputs.build_args}}" == "" ]] && echo "" || echo "--build-arg="${{inputs.build_args}}"")
-        docker build -f $DOCKER_FILE -t $IMAGE_NAME --platform=${{inputs.image_architecture}} $ARGS_OPT .
+        docker build -f $DOCKER_FILE -t $IMAGE_NAME --platform=${{inputs.image_architecture}} ${{inputs.build_options}} .
         docker push $IMAGE_NAME
         echo "::set-output name=image::$IMAGE_NAME"
 

--- a/workflows/composite/build-and-publish-image/action.yml
+++ b/workflows/composite/build-and-publish-image/action.yml
@@ -24,6 +24,9 @@ inputs:
     required: false
     default: 'linux/amd64'
     description: 'The architectures for which to build the images'
+  build_args:
+    required: false
+    description: "Additional arguments for the docker build"
 
 runs:
   using: "composite"
@@ -39,7 +42,8 @@ runs:
         # push it to ECR so that it can
         # be deployed to ECS.
         IMAGE_NAME=$ECR_REGISTRY/${{inputs.repository_name}}:${{inputs.image_name}}
-        docker build -f $DOCKER_FILE -t $IMAGE_NAME --platform=${{inputs.image_architecture}} .
+        ARGS=--build-arg ${{inputs.build_args}}
+        docker build -f $DOCKER_FILE -t $IMAGE_NAME --platform=${{inputs.image_architecture}} $ARGS .
         docker push $IMAGE_NAME
         echo "::set-output name=image::$IMAGE_NAME"
 

--- a/workflows/composite/build-and-publish-image/action.yml
+++ b/workflows/composite/build-and-publish-image/action.yml
@@ -38,9 +38,10 @@ runs:
         # Build a docker container and
         # push it to ECR so that it can
         # be deployed to ECS.
+        export DOCKER_CLI_EXPERIMENTAL=enabled
         IMAGE_NAME=$ECR_REGISTRY/${{inputs.repository_name}}:${{inputs.image_name}}
-        docker build -f $DOCKER_FILE -t $IMAGE_NAME --platform=${{inputs.image_architecture}} .
-        docker push $IMAGE_NAME
+        docker buildx create --name wsq-image-builder --bootstrap --use
+        docker buildx build --platform linux/amd64,linux/arm64 -f $DOCKER_FILE  -t $IMAGE_NAME --push .
         echo "::set-output name=image::$IMAGE_NAME"
 
     - name: Get other actions

--- a/workflows/composite/build-and-publish-image/action.yml
+++ b/workflows/composite/build-and-publish-image/action.yml
@@ -42,9 +42,8 @@ runs:
         # push it to ECR so that it can
         # be deployed to ECS.
         IMAGE_NAME=$ECR_REGISTRY/${{inputs.repository_name}}:${{inputs.image_name}}
-        ARGS=--build-arg=${{inputs.build_args}}
-        ARGS=$(( ${{ inputs.build_args }} != "" ? "--build-arg=${{inputs.build_args}}" : "" ))
-        docker build -f $DOCKER_FILE -t $IMAGE_NAME --platform=${{inputs.image_architecture}} $ARGS .
+        ARGS_OPT=[ -z "${{inputs.build_args}}" ] %% echo "" || echo "--build-arg=${{inputs.build_args}}"
+        docker build -f $DOCKER_FILE -t $IMAGE_NAME --platform=${{inputs.image_architecture}} $ARGS_OPT .
         docker push $IMAGE_NAME
         echo "::set-output name=image::$IMAGE_NAME"
 

--- a/workflows/composite/build-and-publish-image/action.yml
+++ b/workflows/composite/build-and-publish-image/action.yml
@@ -43,7 +43,7 @@ runs:
         # be deployed to ECS.
         IMAGE_NAME=$ECR_REGISTRY/${{inputs.repository_name}}:${{inputs.image_name}}
         ARGS=--build-arg=${{inputs.build_args}}
-        ARGS=$(( ${{ inputs.build_args }} != "" ? --build-arg=${{inputs.build_args}} : "" ))
+        ARGS=$(( ${{ inputs.build_args }} != "" ? "--build-arg=${{inputs.build_args}}" : "" ))
         docker build -f $DOCKER_FILE -t $IMAGE_NAME --platform=${{inputs.image_architecture}} $ARGS .
         docker push $IMAGE_NAME
         echo "::set-output name=image::$IMAGE_NAME"

--- a/workflows/composite/build-and-publish-image/action.yml
+++ b/workflows/composite/build-and-publish-image/action.yml
@@ -43,7 +43,7 @@ runs:
         # be deployed to ECS.
         IMAGE_NAME=$ECR_REGISTRY/${{inputs.repository_name}}:${{inputs.image_name}}
         ARGS=--build-arg=${{inputs.build_args}}
-        ARGS=$(( inputs.build_args == "" ? --build-arg=${{inputs.build_args}} : "" ))
+        ARGS=$(( ${{ inputs.build_args }} != "" ? --build-arg=${{inputs.build_args}} : "" ))
         docker build -f $DOCKER_FILE -t $IMAGE_NAME --platform=${{inputs.image_architecture}} $ARGS .
         docker push $IMAGE_NAME
         echo "::set-output name=image::$IMAGE_NAME"

--- a/workflows/composite/build-and-publish-image/action.yml
+++ b/workflows/composite/build-and-publish-image/action.yml
@@ -42,7 +42,7 @@ runs:
         # push it to ECR so that it can
         # be deployed to ECS.
         IMAGE_NAME=$ECR_REGISTRY/${{inputs.repository_name}}:${{inputs.image_name}}
-        ARGS=--build-arg ${{inputs.build_args}}
+        ARGS=--build-arg=${{inputs.build_args}}
         docker build -f $DOCKER_FILE -t $IMAGE_NAME --platform=${{inputs.image_architecture}} $ARGS .
         docker push $IMAGE_NAME
         echo "::set-output name=image::$IMAGE_NAME"

--- a/workflows/composite/build-and-publish-image/action.yml
+++ b/workflows/composite/build-and-publish-image/action.yml
@@ -42,7 +42,7 @@ runs:
         # push it to ECR so that it can
         # be deployed to ECS.
         IMAGE_NAME=$ECR_REGISTRY/${{inputs.repository_name}}:${{inputs.image_name}}
-        ARGS_OPT=$([[ "${{inputs.build_args}}" == "" ]] && echo "" || echo "--build-arg=${{inputs.build_args}}")
+        ARGS_OPT=$([[ "${{inputs.build_args}}" == "" ]] && echo "" || echo "--build-arg="${{inputs.build_args}}"")
         docker build -f $DOCKER_FILE -t $IMAGE_NAME --platform=${{inputs.image_architecture}} $ARGS_OPT .
         docker push $IMAGE_NAME
         echo "::set-output name=image::$IMAGE_NAME"

--- a/workflows/composite/build-and-publish-image/action.yml
+++ b/workflows/composite/build-and-publish-image/action.yml
@@ -43,6 +43,7 @@ runs:
         # be deployed to ECS.
         IMAGE_NAME=$ECR_REGISTRY/${{inputs.repository_name}}:${{inputs.image_name}}
         ARGS=--build-arg=${{inputs.build_args}}
+        ARGS=$(( inputs.build_args == "" ? --build-arg=${{inputs.build_args}} : "" ))
         docker build -f $DOCKER_FILE -t $IMAGE_NAME --platform=${{inputs.image_architecture}} $ARGS .
         docker push $IMAGE_NAME
         echo "::set-output name=image::$IMAGE_NAME"

--- a/workflows/composite/build-and-publish-image/action.yml
+++ b/workflows/composite/build-and-publish-image/action.yml
@@ -42,7 +42,7 @@ runs:
         # push it to ECR so that it can
         # be deployed to ECS.
         IMAGE_NAME=$ECR_REGISTRY/${{inputs.repository_name}}:${{inputs.image_name}}
-        ARGS_OPT=[[ -z "${{inputs.build_args}}" ]] && echo "" || echo "--build-arg=${{inputs.build_args}}"
+        ARGS_OPT=[[ "${{inputs.build_args}}" == "" ]] && echo "" || echo "--build-arg=${{inputs.build_args}}"
         docker build -f $DOCKER_FILE -t $IMAGE_NAME --platform=${{inputs.image_architecture}} $ARGS_OPT .
         docker push $IMAGE_NAME
         echo "::set-output name=image::$IMAGE_NAME"

--- a/workflows/composite/build-and-publish-image/action.yml
+++ b/workflows/composite/build-and-publish-image/action.yml
@@ -42,7 +42,7 @@ runs:
         # push it to ECR so that it can
         # be deployed to ECS.
         IMAGE_NAME=$ECR_REGISTRY/${{inputs.repository_name}}:${{inputs.image_name}}
-        ARGS_OPT=[ -z "${{inputs.build_args}}" ] %% echo "" || echo "--build-arg=${{inputs.build_args}}"
+        ARGS_OPT=[[ -z "${{inputs.build_args}}" ]] && echo "" || echo "--build-arg=${{inputs.build_args}}"
         docker build -f $DOCKER_FILE -t $IMAGE_NAME --platform=${{inputs.image_architecture}} $ARGS_OPT .
         docker push $IMAGE_NAME
         echo "::set-output name=image::$IMAGE_NAME"

--- a/workflows/composite/build-and-publish-image/action.yml
+++ b/workflows/composite/build-and-publish-image/action.yml
@@ -23,7 +23,7 @@ inputs:
   image_architecture:
     required: false
     default: 'linux/amd64'
-    description: 'The admin github token'
+    description: 'The architectures for which to build the images'
 
 runs:
   using: "composite"
@@ -41,7 +41,7 @@ runs:
         export DOCKER_CLI_EXPERIMENTAL=enabled
         IMAGE_NAME=$ECR_REGISTRY/${{inputs.repository_name}}:${{inputs.image_name}}
         docker buildx create --name wsq-image-builder --bootstrap --use
-        docker buildx build --platform linux/amd64,linux/arm64 -f $DOCKER_FILE  -t $IMAGE_NAME --push .
+        docker buildx build --platform=${{inputs.image_architecture}} -f $DOCKER_FILE  -t $IMAGE_NAME --push .
         echo "::set-output name=image::$IMAGE_NAME"
 
     - name: Get other actions

--- a/workflows/composite/build-and-publish-image/action.yml
+++ b/workflows/composite/build-and-publish-image/action.yml
@@ -42,7 +42,7 @@ runs:
         # push it to ECR so that it can
         # be deployed to ECS.
         IMAGE_NAME=$ECR_REGISTRY/${{inputs.repository_name}}:${{inputs.image_name}}
-        ARGS_OPT=[[ "${{inputs.build_args}}" == "" ]] && echo "" || echo "--build-arg=${{inputs.build_args}}"
+        ARGS_OPT=$([[ "${{inputs.build_args}}" == "" ]] && echo "" || echo "--build-arg=${{inputs.build_args}}")
         docker build -f $DOCKER_FILE -t $IMAGE_NAME --platform=${{inputs.image_architecture}} $ARGS_OPT .
         docker push $IMAGE_NAME
         echo "::set-output name=image::$IMAGE_NAME"

--- a/workflows/composite/build-and-publish-image/action.yml
+++ b/workflows/composite/build-and-publish-image/action.yml
@@ -38,10 +38,9 @@ runs:
         # Build a docker container and
         # push it to ECR so that it can
         # be deployed to ECS.
-        export DOCKER_CLI_EXPERIMENTAL=enabled
         IMAGE_NAME=$ECR_REGISTRY/${{inputs.repository_name}}:${{inputs.image_name}}
-        docker buildx create --name wsq-image-builder --bootstrap --use
-        docker buildx build --platform=${{inputs.image_architecture}} -f $DOCKER_FILE  -t $IMAGE_NAME --push .
+        docker build -f $DOCKER_FILE -t $IMAGE_NAME --platform=${{inputs.image_architecture}} .
+        docker push $IMAGE_NAME
         echo "::set-output name=image::$IMAGE_NAME"
 
     - name: Get other actions


### PR DESCRIPTION
## Related Jira Ticket(s)
https://wildsparq.atlassian.net/browse/WS-2552?atlOrigin=eyJpIjoiNDg0NjM5YjI0Y2VmNGMyZThjNjVjZTU5MmU2NmEzODgiLCJwIjoiaiJ9

## Approach
- Optional input for  a build args flag. Needed for dual-building arm/x86 images.
- Verified successfully builds images with and without the args passed in. 

## Versioning
- [ ] Major (removed external functionality (like an API endpoint))
- [x] Minor (deprecated/added external functionality (like an API endpoint))
- [ ] Patch (updated internal functionality (does not require any external changes))

## Checklist
_Before submitting the PR to the team, please fill out the self-review below_
- [x] I have individually reviewed this PR
- [x] Manual Testing
   - [x] I have manually run this branch to verify the changes work as expected
   - [ ] I have smoke tested existing functionality in the application with these changes
- [x] Automated Testing
    - [ ] I was unable to cover this PR in automated testing due to limitations in our testing infrastructure.
    - [x] The changes in this PR do not require automated testing.
    - [ ] I successfully added/updated automated testing to cover changes in this PR.
- [x] Documentation
    - [x] This PR does not require documentation changes.
    - [ ] I have updated documentation (Confluence, README, etc.) to correspond to the changes in this PR.

## Reviewers:
@wildsparq/developers 
