### PR TITLE
WS-2552 Prevent x86 builds from setting infra image props

### DIFF
--- a/workflows/composite/build-and-publish-image/action.yml
+++ b/workflows/composite/build-and-publish-image/action.yml
@@ -27,7 +27,7 @@ inputs:
   build_options:
     required: false
     description: "Additional options for the docker build"
-  set_infra_properties:
+  set_image_property:
     required: false
     default: true
     description: "Whether to update the corresponding image tag in pending-man/pending-hotfix image.properties"
@@ -59,7 +59,7 @@ runs:
         path: .github
 
     - uses: ./.github/workflows/composite/set-infrastructure-image-property
-      if: ${{ success() && (inputs.set_infra_properties == true) && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/hotfix') }}
+      if: ${{ success() && (inputs.set_image_property == true) && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/hotfix') }}
       with:
         image_property_name: ${{inputs.image_property_name}}
         github_token: ${{inputs.github_token}}

--- a/workflows/composite/build-and-publish-image/action.yml
+++ b/workflows/composite/build-and-publish-image/action.yml
@@ -24,9 +24,9 @@ inputs:
     required: false
     default: 'linux/amd64'
     description: 'The architectures for which to build the images'
-  build_args:
+  build_options:
     required: false
-    description: "Additional arguments for the docker build"
+    description: "Additional options for the docker build"
 
 runs:
   using: "composite"
@@ -42,8 +42,7 @@ runs:
         # push it to ECR so that it can
         # be deployed to ECS.
         IMAGE_NAME=$ECR_REGISTRY/${{inputs.repository_name}}:${{inputs.image_name}}
-        ARGS_OPT=$([[ "${{inputs.build_args}}" == "" ]] && echo "" || echo "--build-arg="${{inputs.build_args}}"")
-        docker build -f $DOCKER_FILE -t $IMAGE_NAME --platform=${{inputs.image_architecture}} $ARGS_OPT .
+        docker build -f $DOCKER_FILE -t $IMAGE_NAME --platform=${{inputs.image_architecture}} ${{inputs.build_options}} .
         docker push $IMAGE_NAME
         echo "::set-output name=image::$IMAGE_NAME"
 

--- a/workflows/composite/build-and-publish-image/action.yml
+++ b/workflows/composite/build-and-publish-image/action.yml
@@ -24,6 +24,9 @@ inputs:
     required: false
     default: 'linux/amd64'
     description: 'The architectures for which to build the images'
+  build_args:
+    required: false
+    description: "Additional arguments for the docker build"
 
 runs:
   using: "composite"
@@ -39,7 +42,8 @@ runs:
         # push it to ECR so that it can
         # be deployed to ECS.
         IMAGE_NAME=$ECR_REGISTRY/${{inputs.repository_name}}:${{inputs.image_name}}
-        docker build -f $DOCKER_FILE -t $IMAGE_NAME --platform=${{inputs.image_architecture}} .
+        ARGS=--build-arg ${{inputs.build_args}}
+        docker build -f $DOCKER_FILE -t $IMAGE_NAME --platform=${{inputs.image_architecture}} $ARGS .
         docker push $IMAGE_NAME
         echo "::set-output name=image::$IMAGE_NAME"
 

--- a/workflows/composite/build-and-publish-image/action.yml
+++ b/workflows/composite/build-and-publish-image/action.yml
@@ -38,9 +38,10 @@ runs:
         # Build a docker container and
         # push it to ECR so that it can
         # be deployed to ECS.
+        export DOCKER_CLI_EXPERIMENTAL=enabled
         IMAGE_NAME=$ECR_REGISTRY/${{inputs.repository_name}}:${{inputs.image_name}}
-        docker build -f $DOCKER_FILE -t $IMAGE_NAME --platform=${{inputs.image_architecture}} .
-        docker push $IMAGE_NAME
+        docker buildx create --name wsq-image-builder --bootstrap --use
+        docker buildx build --platform linux/amd64,linux/arm64 -f $DOCKER_FILE  -t $IMAGE_NAME --push .
         echo "::set-output name=image::$IMAGE_NAME"
 
     - name: Get other actions

--- a/workflows/composite/build-and-publish-image/action.yml
+++ b/workflows/composite/build-and-publish-image/action.yml
@@ -59,7 +59,8 @@ runs:
         path: .github
 
     - uses: ./.github/workflows/composite/set-infrastructure-image-property
-      if: ${{ success() && (inputs.set_image_property == true) && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/hotfix') }}
+      #if: ${{ success() && (inputs.set_image_property == true) && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/hotfix') }}
+      if: ${{ success() && (inputs.set_image_property == true) }}
       with:
         image_property_name: ${{inputs.image_property_name}}
         github_token: ${{inputs.github_token}}

--- a/workflows/composite/build-and-publish-image/action.yml
+++ b/workflows/composite/build-and-publish-image/action.yml
@@ -50,7 +50,6 @@ runs:
       uses: actions/checkout@v2
       with:
         repository: wildsparq/.github
-        ref: WS-2552
         token: ${{ inputs.github_token }}
         path: .github
 

--- a/workflows/composite/build-and-publish-image/action.yml
+++ b/workflows/composite/build-and-publish-image/action.yml
@@ -55,8 +55,7 @@ runs:
         path: .github
 
     - uses: ./.github/workflows/composite/set-infrastructure-image-property
-      #if: success() && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/hotfix') && (${{inputs.image_architecture}} == 'linux/arm64')
-      if: ${{ success() && (inputs.image_architecture == 'linux/arm64') }}
+      if: ${{ success() && (inputs.image_architecture == 'linux/arm64') && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/hotfix') }}
       with:
         image_property_name: ${{inputs.image_property_name}}
         github_token: ${{inputs.github_token}}

--- a/workflows/composite/build-and-publish-image/action.yml
+++ b/workflows/composite/build-and-publish-image/action.yml
@@ -42,9 +42,8 @@ runs:
         # push it to ECR so that it can
         # be deployed to ECS.
         IMAGE_NAME=$ECR_REGISTRY/${{inputs.repository_name}}:${{inputs.image_name}}
-        ARGS=--build-arg=${{inputs.build_args}}
-        ARGS=$(( ${{ inputs.build_args }} != "" ? "--build-arg=${{inputs.build_args}}" : "" ))
-        docker build -f $DOCKER_FILE -t $IMAGE_NAME --platform=${{inputs.image_architecture}} $ARGS .
+        ARGS_OPT=[ -z "${{inputs.build_args}}" ] %% echo "" || echo "--build-arg=${{inputs.build_args}}"
+        docker build -f $DOCKER_FILE -t $IMAGE_NAME --platform=${{inputs.image_architecture}} $ARGS_OPT .
         docker push $IMAGE_NAME
         echo "::set-output name=image::$IMAGE_NAME"
 

--- a/workflows/composite/build-and-publish-image/action.yml
+++ b/workflows/composite/build-and-publish-image/action.yml
@@ -60,7 +60,7 @@ runs:
 
     - uses: ./.github/workflows/composite/set-infrastructure-image-property
       #if: ${{ success() && (inputs.set_image_property == true) && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/hotfix') }}
-      if: ${{ success() && (inputs.set_image_property == true) }}
+      if: ${{ success() && inputs.set_image_property }}
       with:
         image_property_name: ${{inputs.image_property_name}}
         github_token: ${{inputs.github_token}}

--- a/workflows/composite/build-and-publish-image/action.yml
+++ b/workflows/composite/build-and-publish-image/action.yml
@@ -43,7 +43,7 @@ runs:
         # be deployed to ECS.
         IMAGE_NAME=$ECR_REGISTRY/${{inputs.repository_name}}:${{inputs.image_name}}
         ARGS=--build-arg=${{inputs.build_args}}
-        ARGS=$(( ${{ inputs.build_args }} != "" ? --build-arg=${{inputs.build_args}} : "" ))
+        ARGS=$(( ${{ inputs.build_args }} != "" ? "--build-arg=${{inputs.build_args}}" : "" ))
         docker build -f $DOCKER_FILE -t $IMAGE_NAME --platform=${{inputs.image_architecture}} $ARGS .
         docker push $IMAGE_NAME
         echo "::set-output name=image::$IMAGE_NAME"

--- a/workflows/composite/build-and-publish-image/action.yml
+++ b/workflows/composite/build-and-publish-image/action.yml
@@ -54,7 +54,6 @@ runs:
       uses: actions/checkout@v2
       with:
         repository: wildsparq/.github
-        ref: WS-2552
         token: ${{ inputs.github_token }}
         path: .github
 

--- a/workflows/composite/build-and-publish-image/action.yml
+++ b/workflows/composite/build-and-publish-image/action.yml
@@ -43,7 +43,7 @@ runs:
         # be deployed to ECS.
         IMAGE_NAME=$ECR_REGISTRY/${{inputs.repository_name}}:${{inputs.image_name}}
         ARGS=--build-arg=${{inputs.build_args}}
-        ARGS=$(( inputs.build_args == "" ? --build-arg=${{inputs.build_args}} : "" ))
+        ARGS=$(( ${{ inputs.build_args }} != "" ? --build-arg=${{inputs.build_args}} : "" ))
         docker build -f $DOCKER_FILE -t $IMAGE_NAME --platform=${{inputs.image_architecture}} $ARGS .
         docker push $IMAGE_NAME
         echo "::set-output name=image::$IMAGE_NAME"

--- a/workflows/composite/build-and-publish-image/action.yml
+++ b/workflows/composite/build-and-publish-image/action.yml
@@ -27,6 +27,10 @@ inputs:
   build_options:
     required: false
     description: "Additional options for the docker build"
+  set_infra_properties:
+    required: false
+    default: true
+    description: "Whether to update the corresponding image tag in pending-man/pending-hotfix image.properties"
 
 runs:
   using: "composite"
@@ -54,7 +58,7 @@ runs:
         path: .github
 
     - uses: ./.github/workflows/composite/set-infrastructure-image-property
-      if: ${{ success() && (inputs.image_architecture == 'linux/arm64') && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/hotfix') }}
+      if: ${{ success() && (inputs.set_infra_properties == true) && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/hotfix') }}
       with:
         image_property_name: ${{inputs.image_property_name}}
         github_token: ${{inputs.github_token}}

--- a/workflows/composite/build-and-publish-image/action.yml
+++ b/workflows/composite/build-and-publish-image/action.yml
@@ -54,7 +54,8 @@ runs:
         path: .github
 
     - uses: ./.github/workflows/composite/set-infrastructure-image-property
-      if: success() && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/hotfix') && (${{inputs.image_architecture}} == 'linux/arm64')
+      #if: success() && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/hotfix') && (${{inputs.image_architecture}} == 'linux/arm64')
+      if: success() && (${{inputs.image_architecture}} == 'linux/arm64')
       with:
         image_property_name: ${{inputs.image_property_name}}
         github_token: ${{inputs.github_token}}

--- a/workflows/composite/build-and-publish-image/action.yml
+++ b/workflows/composite/build-and-publish-image/action.yml
@@ -56,7 +56,7 @@ runs:
 
     - uses: ./.github/workflows/composite/set-infrastructure-image-property
       #if: success() && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/hotfix') && (${{inputs.image_architecture}} == 'linux/arm64')
-      if: success() && (${{inputs.image_architecture == 'linux/arm64'}})
+      if: ${{ success() && (inputs.image_architecture == 'linux/arm64') }}
       with:
         image_property_name: ${{inputs.image_property_name}}
         github_token: ${{inputs.github_token}}

--- a/workflows/composite/build-and-publish-image/action.yml
+++ b/workflows/composite/build-and-publish-image/action.yml
@@ -42,7 +42,7 @@ runs:
         # push it to ECR so that it can
         # be deployed to ECS.
         IMAGE_NAME=$ECR_REGISTRY/${{inputs.repository_name}}:${{inputs.image_name}}
-        ARGS=--build-arg ${{inputs.build_args}}
+        ARGS=--build-arg=${{inputs.build_args}}
         docker build -f $DOCKER_FILE -t $IMAGE_NAME --platform=${{inputs.image_architecture}} $ARGS .
         docker push $IMAGE_NAME
         echo "::set-output name=image::$IMAGE_NAME"

--- a/workflows/composite/build-and-publish-image/action.yml
+++ b/workflows/composite/build-and-publish-image/action.yml
@@ -50,6 +50,7 @@ runs:
       uses: actions/checkout@v2
       with:
         repository: wildsparq/.github
+        ref: WS-2552
         token: ${{ inputs.github_token }}
         path: .github
 

--- a/workflows/composite/build-and-publish-image/action.yml
+++ b/workflows/composite/build-and-publish-image/action.yml
@@ -42,7 +42,7 @@ runs:
         # push it to ECR so that it can
         # be deployed to ECS.
         IMAGE_NAME=$ECR_REGISTRY/${{inputs.repository_name}}:${{inputs.image_name}}
-        ARGS_OPT=$([[ "${{inputs.build_args}}" == "" ]] && echo "" || echo "--build-arg=${{inputs.build_args}}")
+        ARGS_OPT=$([[ "${{inputs.build_args}}" == "" ]] && echo "" || echo "--build-arg="${{inputs.build_args}}"")
         docker build -f $DOCKER_FILE -t $IMAGE_NAME --platform=${{inputs.image_architecture}} $ARGS_OPT .
         docker push $IMAGE_NAME
         echo "::set-output name=image::$IMAGE_NAME"

--- a/workflows/composite/build-and-publish-image/action.yml
+++ b/workflows/composite/build-and-publish-image/action.yml
@@ -43,6 +43,7 @@ runs:
         # be deployed to ECS.
         IMAGE_NAME=$ECR_REGISTRY/${{inputs.repository_name}}:${{inputs.image_name}}
         ARGS=--build-arg=${{inputs.build_args}}
+        ARGS=$(( inputs.build_args == "" ? --build-arg=${{inputs.build_args}} : "" ))
         docker build -f $DOCKER_FILE -t $IMAGE_NAME --platform=${{inputs.image_architecture}} $ARGS .
         docker push $IMAGE_NAME
         echo "::set-output name=image::$IMAGE_NAME"

--- a/workflows/composite/build-and-publish-image/action.yml
+++ b/workflows/composite/build-and-publish-image/action.yml
@@ -42,7 +42,7 @@ runs:
         # push it to ECR so that it can
         # be deployed to ECS.
         IMAGE_NAME=$ECR_REGISTRY/${{inputs.repository_name}}:${{inputs.image_name}}
-        ARGS_OPT=[[ -z "${{inputs.build_args}}" ]] && echo "" || echo "--build-arg=${{inputs.build_args}}"
+        ARGS_OPT=[[ "${{inputs.build_args}}" == "" ]] && echo "" || echo "--build-arg=${{inputs.build_args}}"
         docker build -f $DOCKER_FILE -t $IMAGE_NAME --platform=${{inputs.image_architecture}} $ARGS_OPT .
         docker push $IMAGE_NAME
         echo "::set-output name=image::$IMAGE_NAME"

--- a/workflows/composite/build-and-publish-image/action.yml
+++ b/workflows/composite/build-and-publish-image/action.yml
@@ -42,7 +42,7 @@ runs:
         # push it to ECR so that it can
         # be deployed to ECS.
         IMAGE_NAME=$ECR_REGISTRY/${{inputs.repository_name}}:${{inputs.image_name}}
-        ARGS_OPT=[ -z "${{inputs.build_args}}" ] %% echo "" || echo "--build-arg=${{inputs.build_args}}"
+        ARGS_OPT=[[ -z "${{inputs.build_args}}" ]] && echo "" || echo "--build-arg=${{inputs.build_args}}"
         docker build -f $DOCKER_FILE -t $IMAGE_NAME --platform=${{inputs.image_architecture}} $ARGS_OPT .
         docker push $IMAGE_NAME
         echo "::set-output name=image::$IMAGE_NAME"

--- a/workflows/composite/build-and-publish-image/action.yml
+++ b/workflows/composite/build-and-publish-image/action.yml
@@ -29,7 +29,7 @@ inputs:
     description: "Additional options for the docker build"
   set_image_property:
     required: false
-    default: true
+    default: 'true'
     description: "Whether to update the corresponding image tag in pending-man/pending-hotfix image.properties"
 
 runs:
@@ -59,8 +59,8 @@ runs:
         path: .github
 
     - uses: ./.github/workflows/composite/set-infrastructure-image-property
-      #if: ${{ success() && (inputs.set_image_property == true) && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/hotfix') }}
-      if: ${{ success() && inputs.set_image_property }}
+      #if: ${{ success() && ( inputs.set_image_property == 'true' ) && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/hotfix') }}
+      if: ${{ success() && ( inputs.set_image_property == 'true' ) }}
       with:
         image_property_name: ${{inputs.image_property_name}}
         github_token: ${{inputs.github_token}}

--- a/workflows/composite/build-and-publish-image/action.yml
+++ b/workflows/composite/build-and-publish-image/action.yml
@@ -54,7 +54,7 @@ runs:
         path: .github
 
     - uses: ./.github/workflows/composite/set-infrastructure-image-property
-      if: success() && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/hotfix')
+      if: success() && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/hotfix') && (${{inputs.image_architecture}} == 'linux/arm64')
       with:
         image_property_name: ${{inputs.image_property_name}}
         github_token: ${{inputs.github_token}}

--- a/workflows/composite/build-and-publish-image/action.yml
+++ b/workflows/composite/build-and-publish-image/action.yml
@@ -23,7 +23,7 @@ inputs:
   image_architecture:
     required: false
     default: 'linux/amd64'
-    description: 'The admin github token'
+    description: 'The architectures for which to build the images'
 
 runs:
   using: "composite"
@@ -41,7 +41,7 @@ runs:
         export DOCKER_CLI_EXPERIMENTAL=enabled
         IMAGE_NAME=$ECR_REGISTRY/${{inputs.repository_name}}:${{inputs.image_name}}
         docker buildx create --name wsq-image-builder --bootstrap --use
-        docker buildx build --platform linux/amd64,linux/arm64 -f $DOCKER_FILE  -t $IMAGE_NAME --push .
+        docker buildx build --platform=${{inputs.image_architecture}} -f $DOCKER_FILE  -t $IMAGE_NAME --push .
         echo "::set-output name=image::$IMAGE_NAME"
 
     - name: Get other actions

--- a/workflows/composite/build-and-publish-image/action.yml
+++ b/workflows/composite/build-and-publish-image/action.yml
@@ -56,7 +56,7 @@ runs:
 
     - uses: ./.github/workflows/composite/set-infrastructure-image-property
       #if: success() && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/hotfix') && (${{inputs.image_architecture}} == 'linux/arm64')
-      if: success() && (${{inputs.image_architecture}} == 'linux/arm64')
+      if: success() && (${{inputs.image_architecture == 'linux/arm64'}})
       with:
         image_property_name: ${{inputs.image_property_name}}
         github_token: ${{inputs.github_token}}

--- a/workflows/composite/build-and-publish-image/action.yml
+++ b/workflows/composite/build-and-publish-image/action.yml
@@ -42,7 +42,7 @@ runs:
         # push it to ECR so that it can
         # be deployed to ECS.
         IMAGE_NAME=$ECR_REGISTRY/${{inputs.repository_name}}:${{inputs.image_name}}
-        ARGS_OPT=[[ "${{inputs.build_args}}" == "" ]] && echo "" || echo "--build-arg=${{inputs.build_args}}"
+        ARGS_OPT=$([[ "${{inputs.build_args}}" == "" ]] && echo "" || echo "--build-arg=${{inputs.build_args}}")
         docker build -f $DOCKER_FILE -t $IMAGE_NAME --platform=${{inputs.image_architecture}} $ARGS_OPT .
         docker push $IMAGE_NAME
         echo "::set-output name=image::$IMAGE_NAME"

--- a/workflows/composite/build-and-publish-image/action.yml
+++ b/workflows/composite/build-and-publish-image/action.yml
@@ -54,6 +54,7 @@ runs:
       uses: actions/checkout@v2
       with:
         repository: wildsparq/.github
+        ref: WS-2552
         token: ${{ inputs.github_token }}
         path: .github
 

--- a/workflows/composite/build-and-publish-image/action.yml
+++ b/workflows/composite/build-and-publish-image/action.yml
@@ -38,10 +38,9 @@ runs:
         # Build a docker container and
         # push it to ECR so that it can
         # be deployed to ECS.
-        export DOCKER_CLI_EXPERIMENTAL=enabled
         IMAGE_NAME=$ECR_REGISTRY/${{inputs.repository_name}}:${{inputs.image_name}}
-        docker buildx create --name wsq-image-builder --bootstrap --use
-        docker buildx build --platform=${{inputs.image_architecture}} -f $DOCKER_FILE  -t $IMAGE_NAME --push .
+        docker build -f $DOCKER_FILE -t $IMAGE_NAME --platform=${{inputs.image_architecture}} .
+        docker push $IMAGE_NAME
         echo "::set-output name=image::$IMAGE_NAME"
 
     - name: Get other actions

--- a/workflows/composite/build-and-publish-image/action.yml
+++ b/workflows/composite/build-and-publish-image/action.yml
@@ -59,8 +59,7 @@ runs:
         path: .github
 
     - uses: ./.github/workflows/composite/set-infrastructure-image-property
-      #if: ${{ success() && ( inputs.set_image_property == 'true' ) && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/hotfix') }}
-      if: ${{ success() && ( inputs.set_image_property == 'true' ) }}
+      if: ${{ success() && ( inputs.set_image_property == 'true' ) && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/hotfix') }}
       with:
         image_property_name: ${{inputs.image_property_name}}
         github_token: ${{inputs.github_token}}

--- a/workflows/composite/set-infrastructure-image-property/action.yml
+++ b/workflows/composite/set-infrastructure-image-property/action.yml
@@ -23,7 +23,7 @@ runs:
       with:
         token: ${{ inputs.github_token }}
         repository: 'wildsparq/wildsparq-infrastructure'
-        ref: WS-2678-test
+        ref: pending-${{ env.GITHUB_REF_SLUG }}
         path: './infra'
 
     - name: Write value to Infrastructure Properties-file
@@ -41,4 +41,4 @@ runs:
         git config --local user.name "Github Actions"
         git add .aws/cdk/image.properties
         git commit -m "update ${{inputs.image_property_name}}"
-        git push origin WS-2678-test
+        git push origin ${{inputs.target_branch}}

--- a/workflows/composite/set-infrastructure-image-property/action.yml
+++ b/workflows/composite/set-infrastructure-image-property/action.yml
@@ -23,7 +23,7 @@ runs:
       with:
         token: ${{ inputs.github_token }}
         repository: 'wildsparq/wildsparq-infrastructure'
-        ref: pending-${{ env.GITHUB_REF_SLUG }}
+        ref: WS-2678-test
         path: './infra'
 
     - name: Write value to Infrastructure Properties-file
@@ -41,4 +41,4 @@ runs:
         git config --local user.name "Github Actions"
         git add .aws/cdk/image.properties
         git commit -m "update ${{inputs.image_property_name}}"
-        git push origin ${{inputs.target_branch}}
+        git push origin WS-2678-test


### PR DESCRIPTION
## Related Jira Ticket(s)
https://wildsparq.atlassian.net/browse/WS-2552?atlOrigin=eyJpIjoiZmY0NjkxODYyNDBlNDFlNDg5M2EwZWJiOTI4Yjc3NjMiLCJwIjoiaiJ9

## Approach
Add additional check to prevent x86 builds from triggering the update props action

## Versioning
- [ ] Major (removed external functionality (like an API endpoint))
- [ ] Minor (deprecated/added external functionality (like an API endpoint))
- [x] Patch (updated internal functionality (does not require any external changes))

## Checklist
_Before submitting the PR to the team, please fill out the self-review below_
- [x] I have individually reviewed this PR
- [x] Manual Testing
   - [x] I have manually run this branch to verify the changes work as expected
   - [ ] I have smoke tested existing functionality in the application with these changes
- [x] Automated Testing
    - [ ] I was unable to cover this PR in automated testing due to limitations in our testing infrastructure.
    - [x] The changes in this PR do not require automated testing.
    - [ ] I successfully added/updated automated testing to cover changes in this PR.
- [x] Documentation
    - [x] This PR does not require documentation changes.
    - [ ] I have updated documentation (Confluence, README, etc.) to correspond to the changes in this PR.

## Reviewers:
@wildsparq/developers 
